### PR TITLE
Added option to set custom headers.

### DIFF
--- a/include/http_rest_client.h
+++ b/include/http_rest_client.h
@@ -36,6 +36,9 @@
 #include "esp_crt_bundle.h"
 #endif
 
+// Custom Headers Implementation
+void http_rest_client_add_header(char* header_key, char* header_value);
+
 /* Certificate handling */
 esp_err_t http_rest_client_init_cert(char *cert, size_t cert_len);
 esp_err_t http_rest_client_deinit_cert(void);

--- a/src/http_rest_client.c
+++ b/src/http_rest_client.c
@@ -43,7 +43,7 @@ void http_rest_client_add_header(char* header_key, char* header_value) {
 }
 
 esp_err_t http_rest_client_set_headers(esp_http_client_handle_t client) {
-    esp_err_t ret;
+    esp_err_t ret = ESP_OK;
     for (int i = 0; i < headers_c; i++) {
 	ret = esp_http_client_set_header(client, headers[i], values[i]);
     }

--- a/src/http_rest_client.c
+++ b/src/http_rest_client.c
@@ -31,6 +31,33 @@ static const char *TAG = "http_rest_client";
 
 static char *certificate;
 
+
+char* headers[100];
+char* values[100];
+int headers_c = 0;
+
+void http_rest_client_add_header(char* header_key, char* header_value) {
+    headers[headers_c] = header_key;
+    values[headers_c] = header_value;
+    headers_c++;
+}
+
+esp_err_t http_rest_client_set_headers(esp_http_client_handle_t client) {
+    esp_err_t ret;
+    for (int i = 0; i < headers_c; i++) {
+	ret = esp_http_client_set_header(client, headers[i], values[i]);
+    }
+    return ret;
+}
+
+void http_rest_client_clear_headers() {
+    for (int i = 0; i < headers_c; i++) {
+	headers[i] = NULL;	
+	values[i] = NULL;
+    }
+    headers_c = 0;
+}
+
 esp_err_t http_rest_client_init_cert(char *cert, size_t cert_len)
 {
   if (certificate != NULL)
@@ -88,6 +115,11 @@ esp_err_t http_rest_client_get(char *url, http_rest_recv_buffer_t *http_rest_rec
   client = esp_http_client_init(&config);
 
   esp_http_client_set_header(client, "Content-Type", "application/json");
+  ret = http_rest_client_set_headers(client);
+  if (ret != ESP_OK) {
+    ESP_LOGE(TAG, "Failed to set headers");
+    return ret;
+  }
 
   ret = esp_http_client_perform(client);
 
@@ -141,6 +173,11 @@ esp_err_t http_rest_client_delete(char *url, http_rest_recv_buffer_t *http_rest_
   client = esp_http_client_init(&config);
 
   esp_http_client_set_header(client, "Content-Type", "application/json");
+  ret = http_rest_client_set_headers(client);
+  if (ret != ESP_OK) {
+    ESP_LOGE(TAG, "Failed to set headers");
+    return ret;
+  }
 
   ret = esp_http_client_perform(client);
 
@@ -193,6 +230,11 @@ esp_err_t http_rest_client_post(char *url, char *body_data, http_rest_recv_buffe
   client = esp_http_client_init(&config);
 
   esp_http_client_set_header(client, "Content-Type", "application/json");
+  ret = http_rest_client_set_headers(client);
+  if (ret != ESP_OK) {
+    ESP_LOGE(TAG, "Failed to set headers");
+    return ret;
+  }
 
   esp_http_client_set_post_field(client, body_data, strlen(body_data));
 
@@ -247,6 +289,11 @@ esp_err_t http_rest_client_put(char *url, char *body_data, http_rest_recv_buffer
   client = esp_http_client_init(&config);
 
   esp_http_client_set_header(client, "Content-Type", "application/json");
+  ret = http_rest_client_set_headers(client);
+  if (ret != ESP_OK) {
+    ESP_LOGE(TAG, "Failed to set headers");
+    return ret;
+  }
 
   esp_http_client_set_post_field(client, body_data, strlen(body_data));
 
@@ -277,5 +324,6 @@ void http_rest_client_cleanup(http_rest_recv_buffer_t *http_rest_recv_buffer)
   {
     free(http_rest_recv_buffer->buffer);
   }
+  http_rest_client_clear_headers();
   ESP_LOGD(TAG, "Cleaned up http_rest_recv_buffer");
 }


### PR DESCRIPTION
Hi, I was using your library, and I need to set custom headers.

Since I'm using your lib as a submodule, I felt like doing this pull request.
I tested it and it works flawlessly.

In the future I might do some updates to it so we can clean it up. 

> For example, you set `Application/json` header to all requests, and people may not want that.

Cheers!